### PR TITLE
Rebranded and fix phpstan erros with updates of composer.json.

### DIFF
--- a/.cs-default-rules.php
+++ b/.cs-default-rules.php
@@ -1,35 +1,35 @@
 <?php
 /**
- * The file is part of the "getonecms/dev-tools", OneCMS development tools.
+ * The file is part of the "webifycms/dev-tools", WebifyCMS development tools.
  *
- * @see https://getonecms.com/tools/development-tools
+ * @see https://webifycms.com/tools/development-tools
  *
- * @license Copyright (c) 2022 OneCMS
- * @license https://getonecms.com/extension/tools/license
+ * @license Copyright (c) 2022 WebifyCMS
+ * @license https://webifycms.com/extension/tools/license
  * @author Mohammed Shifreen <mshifreen@gmail.com>
  */
 
 declare(strict_types=1);
 
 return [
-	'@PSR12'                  	      	=> true,
-	'@PSR12:risky'                 	 	=> true,
-	'@PHP80Migration:risky'        	 	=> true,
-	'@PHP81Migration'              	 	=> true,
-	'@PhpCsFixer'                  	 	=> true,
-	'@PhpCsFixer:risky'            	 	=> true,
-	'binary_operator_spaces'       	 	=> [ // overrides that inherits from @PhpCsFixer rule
-		'operators' => [
-			'=>' => 'align',
-			'='  => 'align',
-			'|'  => 'no_space',
-		],
-	],
-	'concat_space' => ['spacing' => 'one'], // overrides that inherits from @PhpCsFixer rule
-	'yoda_style'   => [
-		'equal'                => true,
-		'identical'            => true,
-		'less_and_greater'     => true,
-		'always_move_variable' => true,
-	],
+    '@PSR12'                  	      	=> true,
+    '@PSR12:risky'                 	 	=> true,
+    '@PHP80Migration:risky'        	 	=> true,
+    '@PHP81Migration'              	 	=> true,
+    '@PhpCsFixer'                  	 	=> true,
+    '@PhpCsFixer:risky'            	 	=> true,
+    'binary_operator_spaces'       	 	=> [ // overrides that inherits from @PhpCsFixer rule
+        'operators' => [
+            '=>' => 'align',
+            '='  => 'align',
+            '|'  => 'no_space',
+        ],
+    ],
+    'concat_space' => ['spacing' => 'one'], // overrides that inherits from @PhpCsFixer rule
+    'yoda_style'   => [
+        'equal'                => true,
+        'identical'            => true,
+        'less_and_greater'     => true,
+        'always_move_variable' => true,
+    ],
 ];

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
+/.idea/
 /.vscode/
 .php-cs-fixer.cache
 .php-cs-fixer.php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OneCMS Dev Tools
+# WebifyCMS Dev Tools
 
-Set of development tools to analyze and auto fix code standards, formatting and other stuffs for OneCMS packages.
+Set of development tools to analyze and auto fix code standards, formatting and other stuffs for WebifyCMS packages.
 
 The following libraries are included:
 
@@ -16,15 +16,15 @@ First add the following to your `composer.json`
 "repositories": [
   {
     "type": "vcs",
-    "url": "https://github.com/getonecms/dev-tools"
+    "url": "https://github.com/webifycms/dev-tools"
   }
 ]
 ```
 
-Now it can be install via composer
+Now it can be installed via composer
 
 ```bash
-composer require getonecms/dev-tools --dev
+composer require webifycms/dev-tools --dev
 ```
 
 ## Configuration
@@ -34,7 +34,7 @@ composer require getonecms/dev-tools --dev
 You can add the rules and finder instance in the following way to your config file `.php-cs-fixer.php`:
 
 ```php
-use OneCMS\Tools\Fixer;
+use Webify\Tools\Fixer;
 use PhpCsFixer\Finder;
 
 // create a finder instance according to your needs
@@ -52,7 +52,7 @@ Add `phpstan.neon` in the root directory and you can include `src/phpstan.neon` 
 ```neon
 ...
 includes:
-  - vendor/getonecms/dev-tools/src/phpstan.neon
+  - vendor/webifycms/dev-tools/src/phpstan.neon
 ...
 ```
 
@@ -61,7 +61,7 @@ includes:
 Add `rector.php` in the root directory and the following, if you need to add more paths you can add them as well:
 
 ```php
-use OneCMS\Tools\Rector;
+use Webify\Tools\Rector;
 
 // Initialize
 return (new Rector())->initialize([
@@ -80,19 +80,20 @@ vendor/bin/phpstan analyse [options] [<paths>...]
 
 - Run code sniffer and format your codes.
 
-(Recommended) If you wish to fix manually you can just output the rules that will apply like the following.
+(Recommended) If you wish to fix manually, you can just output the rules that will apply like the following.
 
 ```bash
 ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --show-progress=dots
 ```
 
-If you wish to auto fix the files and output the summary of changes you can run the following.
+If you wish to auto fix the files, and output the summary of changes you can run the following.
 
 ```bash
 ./vendor/bin/php-cs-fixer fix --verbose --show-progress=dots
 ```
 
->***NOTE:** You can also setup this extension with your favorite IDE or editor, so you can able to get more advantages like format on save while developing.*
+>***NOTE:** You can also set up this extension with your favorite IDE or editor, so you can get more 
+> advantages like format on save while developing.*
 
 ## TODO
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "getonecms/dev-tools",
-    "description": "Set of development tools to analyze and auto fix code standards, formatting and other stuffs for OneCMS packages.",
-    "type": "onecms-tool",
+    "name": "webifycms/dev-tools",
+    "description": "Set of development tools to analyze and auto fix code standards, formatting and other stuffs for WebifyCMS packages.",
+    "type": "webifycms-tool",
     "authors": [
         {
             "name": "Mohammed Shifreen",
@@ -18,12 +18,12 @@
     },
     "autoload": {
         "psr-4": {
-            "OneCMS\\Tools\\": "src/"
+            "Webify\\Tools\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "OneCMS\\Base\\Test\\": "test/"
+            "Webify\\Tools\\Test\\": "test/"
         }
     },
     "optimize-autoloader": true,

--- a/phpstan-default.neon
+++ b/phpstan-default.neon
@@ -1,9 +1,9 @@
-# The file is part of the "getonecms/dev-tools", OneCMS development tools.
+# The file is part of the "webifycms/dev-tools", WebifyCMS development tools.
 #
-# @see https://getonecms.com/tools/development-tools
+# @see https://webifycms.com/tools/development-tools
 #
-# @license Copyright (c) 2022 OneCMS
-# @license https://getonecms.com/extension/tools/license
+# @license Copyright (c) 2022 WebifyCMS
+# @license https://webifycms.com/extension/tools/license
 # @author Mohammed Shifreen <mshifreen@gmail.com>
 
 parameters:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,9 @@
-# The file is part of the "getonecms/dev-tools", OneCMS development tools.
+# The file is part of the "webifycms/dev-tools", WebifyCMS development tools.
 #
-# @see https://getonecms.com/tools/development-tools
+# @see https://webifycms.com/tools/development-tools
 #
-# @license Copyright (c) 2022 OneCMS
-# @license https://getonecms.com/extension/tools/license
+# @license Copyright (c) 2022 WebifyCMS
+# @license https://webifycms.com/extension/tools/license
 # @author Mohammed Shifreen <mshifreen@gmail.com>
 
 includes:

--- a/rector.php
+++ b/rector.php
@@ -1,21 +1,20 @@
 <?php
-
 /**
- * The file is part of the "getonecms/dev-tools", OneCMS extension package.
+ * The file is part of the "webifycms/dev-tools", WebifyCMS development tools.
  *
- * @see https://getonecms.com/extension/tools
+ * @see https://webifycms.com/tools/development-tools
  *
- * @copyright Copyright (c) 2022 OneCMS
- * @license https://getonecms.com/extension/tools/license
- * @author  Mohammed Shifreen <mshifreen@gmail.com>
+ * @license Copyright (c) 2022 WebifyCMS
+ * @license https://webifycms.com/extension/tools/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
  */
 
 declare(strict_types=1);
 
-use OneCMS\Tools\Rector;
+use Webify\Tools\Rector;
 
 // Initialize
 return (new Rector())->initialize([
-    __DIR__ . '/src',
-    __DIR__ . '/test'
+    __DIR__.'/src',
+    __DIR__.'/test',
 ]);

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -1,77 +1,77 @@
 <?php
 /**
- * The file is part of the "getonecms/dev-tools", OneCMS development tools.
+ * The file is part of the "webifycms/dev-tools", WebifyCMS development tools.
  *
- * @see https://getonecms.com/tools/development-tools
+ * @see https://webifycms.com/tools/development-tools
  *
- * @license Copyright (c) 2022 OneCMS
- * @license https://getonecms.com/extension/tools/license
+ * @license Copyright (c) 2022 WebifyCMS
+ * @license https://webifycms.com/extension/tools/license
  * @author Mohammed Shifreen <mshifreen@gmail.com>
  */
 
 declare(strict_types=1);
 
-namespace OneCMS\Tools;
+namespace Webify\Tools;
 
 use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Finder;
+use function dirname;
 
 /**
  * The PHP Standard fixer class.
  */
 final class Fixer
 {
-	/**
-	 * The rules.
-	 *
-	 * @var array<string>
-	 */
-	private readonly array $rules;
+    /**
+     * The rules.
+     *
+     * @var array<string, array<string, mixed>|bool>
+     */
+    private readonly array $rules;
 
-	/**
-	 * The config object.
-	 */
-	private readonly ConfigInterface $config;
+    /**
+     * The config object.
+     */
+    private readonly ConfigInterface $config;
 
-	/**
-	 * The class constructor.
-	 *
-	 * @param array<string> $rules
-	 */
-	public function __construct(
-		public readonly Finder $finder,
-		array $rules = []
-	) {
-		$this->rules  = $this->mergeRules($rules);
-		$this->config = (new Config())
-			->setRules($this->rules)
-			->setFinder($this->finder)
-			->setIndent("\t")
-			->setLineEnding("\n")
-			->setRiskyAllowed(true)
-		;
-	}
+    /**
+     * The class constructor.
+     *
+     * @param array<string, array<string, mixed>|bool> $rules
+     */
+    public function __construct(
+        public readonly Finder $finder,
+        array                  $rules = []
+    ) {
+        $this->rules = $this->mergeRules($rules);
+        $this->config = (new Config())
+            ->setRules($this->rules)
+            ->setFinder($this->finder)
+            ->setIndent("\t")
+            ->setLineEnding("\n")
+            ->setRiskyAllowed(true);
+    }
 
-	/**
-	 * Returns fixer configuration.
-	 */
-	public function getConfig(): ConfigInterface
-	{
-		return $this->config;
-	}
+    /**
+     * Merge the given rules with the default rules.
+     *
+     * @param array<string, array<string, mixed>|bool> $rules
+     *
+     * @return array<string, array<string, mixed>|bool>
+     */
+    private function mergeRules(array $rules): array
+    {
+        $defaultRulesSet = require dirname(__DIR__) . '/.cs-default-rules.php';
 
-	/**
-	 * Merge the given rules with the default rules.
-	 *
-	 * @param array<string> $rules
-	 *
-	 * @return array<string>
-	 */
-	private function mergeRules(array $rules): array
-	{
-		$defaultRulesSet = require \dirname(__DIR__) . '/.cs-default-rules.php';
+        return array_merge($defaultRulesSet, $rules);
+    }
 
-		return array_merge($defaultRulesSet, $rules);
-	}
+    /**
+     * Returns fixer configuration.
+     */
+    public function getConfig(): ConfigInterface
+    {
+        return $this->config;
+    }
 }

--- a/src/Rector.php
+++ b/src/Rector.php
@@ -1,18 +1,19 @@
 <?php
 /**
- * The file is part of the "getonecms/dev-tools", OneCMS development tools.
+ * The file is part of the "webifycms/dev-tools", WebifyCMS development tools.
  *
- * @see https://getonecms.com/tools/development-tools
+ * @see https://webifycms.com/tools/development-tools
  *
- * @license Copyright (c) 2022 OneCMS
- * @license https://getonecms.com/extension/tools/license
+ * @license Copyright (c) 2022 WebifyCMS
+ * @license https://webifycms.com/extension/tools/license
  * @author Mohammed Shifreen <mshifreen@gmail.com>
  */
 
 declare(strict_types=1);
 
-namespace OneCMS\Tools;
+namespace Webify\Tools;
 
+use Closure;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Property\TypedPropertyRector;
@@ -23,23 +24,23 @@ use Rector\Set\ValueObject\SetList;
  */
 final class Rector
 {
-	/**
-	 * Initialize the rector.
-	 *
-	 * @param array<string> $paths
-	 */
-	public function initialize(array $paths): \Closure
-	{
-		return static function (RectorConfig $rectorConfig) use ($paths): void {
-			// sets the paths
-			$rectorConfig->paths($paths);
-			// defined sets of rules
-			$rectorConfig->sets([
-				SetList::PHP_81,
-			]);
-			// register a single rule
-			$rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
-			$rectorConfig->rule(TypedPropertyRector::class);
-		};
-	}
+    /**
+     * Initialize the rector.
+     *
+     * @param array<string> $paths
+     */
+    public function initialize(array $paths): Closure
+    {
+        return static function (RectorConfig $rectorConfig) use ($paths): void {
+            // sets the paths
+            $rectorConfig->paths($paths);
+            // defined sets of rules
+            $rectorConfig->sets([
+                SetList::PHP_81,
+            ]);
+            // register a single rule
+            $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+            $rectorConfig->rule(TypedPropertyRector::class);
+        };
+    }
 }


### PR DESCRIPTION
1. Rebranded from OneCMS to WebifyCMS by replacing the name used in all the files including the namespaces. 
2. Fixed phpstan errors which is related type of array.
3. Updated composer.json accordingly.